### PR TITLE
fix: apply UV scale and add triplanar mapping support

### DIFF
--- a/addons/psx_visuals_gd4/scripts/AutoApply.gd
+++ b/addons/psx_visuals_gd4/scripts/AutoApply.gd
@@ -13,10 +13,10 @@ func _on_node_added(node):
 	if node is GeometryInstance3D:
 		if node is Label3D:
 			return
-		
+
 		if node is GPUParticles3D:
 			return
-		
+
 		if node is CPUParticles3D:
 			return
 
@@ -94,10 +94,18 @@ func _apply_ps1_shader(node: GeometryInstance3D):
 			if original_mat.albedo_texture:
 				new_mat.set_shader_parameter("albedo", original_mat.albedo_texture)
 
-			# 2. Copy the Albedo Tint/Color
+			# 2. Copy the Albedo scale
+			new_mat.set_shader_parameter("albedo_scale", Vector2(original_mat.uv1_scale.x, original_mat.uv1_scale.y))
+
+			# 3. Copy the Albedo Tint/Color
 			new_mat.set_shader_parameter("albedo_tint", original_mat.albedo_color)
 
-			# 3. Handle Emission
+			# 3b. Copy triplanar settings
+			new_mat.set_shader_parameter("triplanar", original_mat.uv1_triplanar)
+			new_mat.set_shader_parameter("triplanar_sharpness", original_mat.uv1_triplanar_sharpness)
+			new_mat.set_shader_parameter("world_triplanar", original_mat.uv1_world_triplanar)
+
+			# 4. Handle Emission
 			if original_mat.emission_enabled:
 				new_mat.set_shader_parameter("emission", original_mat.emission_texture)
 				new_mat.set_shader_parameter("emission_tint", original_mat.emission)

--- a/addons/psx_visuals_gd4/shaders/psx.gdshaderinc
+++ b/addons/psx_visuals_gd4/shaders/psx.gdshaderinc
@@ -18,7 +18,7 @@ vec4 dither(vec4 color, vec2 uv, int depth) {
 
 vec3 snap(vec3 vertex, mat4 matrix, float scale) {
 	if (scale == 0.0) return vertex;
-	
+
 	vec3 v = (matrix * vec4(vertex, 1.0)).xyz;
 	v = round(v / scale) * scale;
 	return (inverse(matrix) * vec4(v, 1.0)).xyz;
@@ -40,17 +40,29 @@ uniform sampler2D albedo: hint_default_white, filter_nearest;
 uniform vec4 albedo_tint: source_color = vec4(1);
 uniform sampler2D emission: hint_default_black, filter_nearest;
 uniform vec3 emission_tint: source_color = vec3(1);
+uniform vec2 albedo_scale = vec2(1.0);
+
+// Triplanar mapping uniforms
+uniform bool triplanar = false;
+uniform float triplanar_sharpness: hint_range(0.01, 8.0, 0.01) = 1.0;
+uniform bool world_triplanar = true;
 
 varying vec3 VERTEX_COLOR;
 varying float VERTEX_DEPTH;
 varying float fog_strength;
 varying vec2 affine_uv_scaled;
 
+// Triplanar varyings
+varying vec3 frag_world_pos;
+varying vec3 frag_local_pos;
+varying vec3 frag_world_normal;
+varying vec3 frag_local_normal;
+
 // --- SPATIAL LOGIC HELPERS ---
 
 void psx_compute_vertex(inout vec3 vertex, vec3 color, vec2 uv, out vec3 out_color, out float out_depth, out float out_fog, out vec2 out_affine_uv) {
 	out_color = color;
-	// GODOT 4 FIX: VERTEX is already in View Space. 
+	// GODOT 4 FIX: VERTEX is already in View Space.
 	// We snap it directly without multiplying by MODELVIEW_MATRIX.
 	vertex = round(vertex / psx_snap_distance) * psx_snap_distance;
 
@@ -58,7 +70,7 @@ void psx_compute_vertex(inout vec3 vertex, vec3 color, vec2 uv, out vec3 out_col
 	// Since the camera is at (0,0,0) in View Space, length(VERTEX) is the distance.
 	out_depth = length(vertex);
 	out_affine_uv = uv * out_depth;
-	
+
 	out_fog = (use_global_fog && psx_fog_near != psx_fog_far) ?
 		clamp(psx_fog_color.a * (out_depth - psx_fog_near) / (psx_fog_far - psx_fog_near), 0.0, 1.0) :
 		0.0;
@@ -72,17 +84,54 @@ void psx_compute_backface_normal(vec3 vertex, inout vec3 normal) {
 	if (back_facing) normal = -normal;
 }
 
-void psx_compute_fragment(vec2 uv_in, inout vec3 albedo_out, inout float alpha_out, inout vec3 emission_out) {
+// Triplanar texture sampling helper
+vec4 triplanar_sample(sampler2D tex, vec3 position, vec3 normal, vec2 uv_scale) {
+	vec3 blending = abs(normal);
+	blending = max(blending, 0.00001);
+	blending = normalize(blending);
+	float total = blending.x + blending.y + blending.z;
+	blending /= total;
+
+	if (triplanar_sharpness != 1.0) {
+		blending = pow(blending, vec3(triplanar_sharpness));
+		total = blending.x + blending.y + blending.z;
+		blending /= total;
+	}
+
+	vec4 x_sample = texture(tex, position.yz * uv_scale);
+	vec4 y_sample = texture(tex, position.xz * uv_scale);
+	vec4 z_sample = texture(tex, position.xy * uv_scale);
+
+	return x_sample * blending.x + y_sample * blending.y + z_sample * blending.z;
+}
+
+void psx_compute_fragment(vec2 uv_in, vec3 world_pos, vec3 world_normal_in, vec3 local_pos, vec3 local_normal_in, inout vec3 albedo_out, inout float alpha_out, inout vec3 emission_out) {
+	vec2 scaled_uv = uv_in * albedo_scale;
 	vec2 affine_uv = affine_uv_scaled / VERTEX_DEPTH;
-	vec2 uv = mix(uv_in, affine_uv, psx_affine_strength);
+	// FIX: Use scaled_uv instead of uv_in so albedo_scale is applied
+	vec2 uv = mix(scaled_uv, affine_uv, psx_affine_strength);
 
 	vec3 fog_rgb = mix(vec3(0), psx_fog_color.rgb, fog_strength);
 
-	vec4 albedo_color = texture(albedo, uv) * albedo_tint;
+	vec4 albedo_color;
+	vec4 emission_color;
+
+	if (triplanar) {
+		vec3 tp_pos = world_triplanar ? world_pos : local_pos;
+		vec3 tp_normal = world_triplanar ? normalize(world_normal_in) : normalize(local_normal_in);
+
+		albedo_color = triplanar_sample(albedo, tp_pos, tp_normal, albedo_scale);
+		albedo_color *= albedo_tint;
+		emission_color = triplanar_sample(emission, tp_pos, tp_normal, albedo_scale);
+		emission_color *= vec4(emission_tint, 1.0);
+	} else {
+		albedo_color = texture(albedo, uv) * albedo_tint;
+		emission_color = texture(emission, uv) * vec4(emission_tint, 1.0);
+	}
+
 	if (use_vertex_colors_in_albedo) albedo_color *= vec4(VERTEX_COLOR, 1.0);
-	
+
 	albedo_out = albedo_color.rgb * (1.0 - fog_strength) + fog_rgb;
 	alpha_out = albedo_color.a;
-	vec4 emission_color = texture(emission, uv) * vec4(emission_tint, 1.0);
 	emission_out = emission_color.rgb + fog_rgb;
 }

--- a/addons/psx_visuals_gd4/shaders/psx_opaque.gdshader
+++ b/addons/psx_visuals_gd4/shaders/psx_opaque.gdshader
@@ -11,16 +11,24 @@ void vertex() {
 	float v_fog;
 	vec2 v_affine;
 	
+	// Capture local position before snapping for triplanar
+	frag_local_pos = VERTEX;
+	
 	psx_compute_vertex(VERTEX, COLOR.rgb, UV, v_col, v_depth, v_fog, v_affine);
 	
 	VERTEX_COLOR = v_col;
 	VERTEX_DEPTH = v_depth;
 	fog_strength = v_fog;
 	affine_uv_scaled = v_affine;
+	
+	// Compute world-space position and normal for triplanar
+	frag_world_pos = (INV_VIEW_MATRIX * (MODELVIEW_MATRIX * vec4(frag_local_pos, 1.0))).xyz;
+	frag_world_normal = (INV_VIEW_MATRIX * (MODELVIEW_MATRIX * vec4(NORMAL, 0.0))).xyz;
+	frag_local_normal = NORMAL;
 }
 
 void fragment() {
-	psx_compute_fragment(UV, ALBEDO, ALPHA, EMISSION);
+	psx_compute_fragment(UV, frag_world_pos, frag_world_normal, frag_local_pos, frag_local_normal, ALBEDO, ALPHA, EMISSION);
 	
 	ALPHA_SCISSOR_THRESHOLD = alpha_scissor_threshold;
 	SPECULAR = 0.0;

--- a/addons/psx_visuals_gd4/shaders/psx_opaque_double.gdshader
+++ b/addons/psx_visuals_gd4/shaders/psx_opaque_double.gdshader
@@ -14,20 +14,30 @@ void vertex() {
 	float v_fog;
 	vec2 v_affine;
 	
+	// Capture local position before snapping for triplanar
+	frag_local_pos = VERTEX;
+	
 	psx_compute_vertex(VERTEX, COLOR.rgb, UV, v_col, v_depth, v_fog, v_affine);
 	
 	VERTEX_COLOR = v_col;
 	VERTEX_DEPTH = v_depth;
 	fog_strength = v_fog;
 	affine_uv_scaled = v_affine;
+	
+	// Compute world-space position
+	frag_world_pos = (INV_VIEW_MATRIX * (MODELVIEW_MATRIX * vec4(frag_local_pos, 1.0))).xyz;
 
 	if (flip_backface_normals) {
 		psx_compute_backface_normal(VERTEX, NORMAL);
 	}
+	
+	// Compute normals after backface correction
+	frag_world_normal = (INV_VIEW_MATRIX * (MODELVIEW_MATRIX * vec4(NORMAL, 0.0))).xyz;
+	frag_local_normal = NORMAL;
 }
 
 void fragment() {
-	psx_compute_fragment(UV, ALBEDO, ALPHA, EMISSION);
+	psx_compute_fragment(UV, frag_world_pos, frag_world_normal, frag_local_pos, frag_local_normal, ALBEDO, ALPHA, EMISSION);
 
 	ALPHA_SCISSOR_THRESHOLD = alpha_scissor_threshold;
 	SPECULAR = 0.0;

--- a/addons/psx_visuals_gd4/shaders/psx_transparent.gdshader
+++ b/addons/psx_visuals_gd4/shaders/psx_transparent.gdshader
@@ -9,16 +9,24 @@ void vertex() {
 	float v_fog;
 	vec2 v_affine;
 	
+	// Capture local position before snapping for triplanar
+	frag_local_pos = VERTEX;
+	
 	psx_compute_vertex(VERTEX, COLOR.rgb, UV, v_col, v_depth, v_fog, v_affine);
 	
 	VERTEX_COLOR = v_col;
 	VERTEX_DEPTH = v_depth;
 	fog_strength = v_fog;
 	affine_uv_scaled = v_affine;
+	
+	// Compute world-space position and normal for triplanar
+	frag_world_pos = (INV_VIEW_MATRIX * (MODELVIEW_MATRIX * vec4(frag_local_pos, 1.0))).xyz;
+	frag_world_normal = (INV_VIEW_MATRIX * (MODELVIEW_MATRIX * vec4(NORMAL, 0.0))).xyz;
+	frag_local_normal = NORMAL;
 }
 
 void fragment() {
-	psx_compute_fragment(UV, ALBEDO, ALPHA, EMISSION);
+	psx_compute_fragment(UV, frag_world_pos, frag_world_normal, frag_local_pos, frag_local_normal, ALBEDO, ALPHA, EMISSION);
 
 	SPECULAR = 0.0;
 	ROUGHNESS = 0.0;

--- a/addons/psx_visuals_gd4/shaders/psx_transparent_double.gdshader
+++ b/addons/psx_visuals_gd4/shaders/psx_transparent_double.gdshader
@@ -12,20 +12,30 @@ void vertex() {
 	float v_fog;
 	vec2 v_affine;
 	
+	// Capture local position before snapping for triplanar
+	frag_local_pos = VERTEX;
+	
 	psx_compute_vertex(VERTEX, COLOR.rgb, UV, v_col, v_depth, v_fog, v_affine);
 	
 	VERTEX_COLOR = v_col;
 	VERTEX_DEPTH = v_depth;
 	fog_strength = v_fog;
 	affine_uv_scaled = v_affine;
+	
+	// Compute world-space position
+	frag_world_pos = (INV_VIEW_MATRIX * (MODELVIEW_MATRIX * vec4(frag_local_pos, 1.0))).xyz;
 
 	if (flip_backface_normals) {
 		psx_compute_backface_normal(VERTEX, NORMAL);
 	}
+	
+	// Compute normals after backface correction
+	frag_world_normal = (INV_VIEW_MATRIX * (MODELVIEW_MATRIX * vec4(NORMAL, 0.0))).xyz;
+	frag_local_normal = NORMAL;
 }
 
 void fragment() {
-	psx_compute_fragment(UV, ALBEDO, ALPHA, EMISSION);
+	psx_compute_fragment(UV, frag_world_pos, frag_world_normal, frag_local_pos, frag_local_normal, ALBEDO, ALPHA, EMISSION);
 	SPECULAR = 0.0;
 	ROUGHNESS = 0.0;
 	METALLIC = 0.0;


### PR DESCRIPTION
## Fixes  
  
### 1. UV scale was silently ignored  
`scaled_uv` computed from `albedo_scale` but never used -- raw `uv_in` sampled instead.  
  
### 2. Triplanar mapping not supported  
AutoApply copied albedo_texture, albedo_scale, albedo_tint but ignored uv1_triplanar, uv1_triplanar_sharpness, world_triplanar.  
  
### Changes  
- Added triplanar uniforms and varyings to psx.gdshaderinc  
- Implemented triplanar_sample() helper with sharpness blending  
- Fixed albedo_scale bug in psx_compute_fragment  
- Spatial shaders compute world pos via INV_VIEW_MATRIX * MODELVIEW_MATRIX  
- AutoApply.gd copies triplanar settings from StandardMaterial3D  
  
Compat: Avoids MODEL_MATRIX since canvas_item postprocess shader includes same file. Uses pow(vec3, vec3(float)) for Godot shader type strictness. 
